### PR TITLE
Allow higher CairoSVG versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,14 +4,14 @@ from distutils.core import setup
 
 setup(
     name='avinit',
-    version='1.2.2',
+    version='1.3.0',
     description='Generate avatars using name initials',
     author='Sergio Oliveira',
     author_email='seocam@seocam.com',
     url='https://github.com/CraveFood/avinit',
     packages=['avinit'],
     extras_require={
-        'png': ['CairoSVG>=1.0,<2.0.0', 'cairocffi<1.0.2']
+        'png': ['CairoSVG>=1.0']
     },
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Newest CairoSVG versions (based on CairoCFFI) requires Python 3.5+; The 3.5 version has been released for almost 4 years now, and meets the Py3 minimum version of at least all 20 most-used distributions on DistroWatch (didn't look further than that).

If someone is still using Python 2 or <=3.4, the current code should still be compatible anyway.

- Closes #7 